### PR TITLE
Modify build controller watches secrets integration tests

### DIFF
--- a/test/catalog.go
+++ b/test/catalog.go
@@ -31,6 +31,27 @@ import (
 // Catalog allows you to access helper functions
 type Catalog struct{}
 
+// SecretWithAnnotation gives you a secret with build annotation
+func (c *Catalog) SecretWithAnnotation(name string, ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Namespace: ns,
+			Annotations: map[string]string{build.AnnotationBuildRefSecret: "true"},
+		},
+	}
+}
+
+// SecretWithoutAnnotation gives you a secret without build annotation
+func (c *Catalog) SecretWithoutAnnotation(name string, ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Namespace: ns,
+		},
+	}
+}
+
 // BuildWithClusterBuildStrategy gives you an specific Build CRD
 func (c *Catalog) BuildWithClusterBuildStrategy(name string, ns string, strategyName string, secretName string) *build.Build {
 	buildStrategy := build.ClusterBuildStrategyKind


### PR DESCRIPTION
- Move secret sample to cataLog file;
- Delete validate secret events test;
  - For secret create event can be checked by `"should not validate when a missing secret is recreated without annotation"`, `"should validate when a missing secret is recreated"` and `"should validate when a missing secret is recreated with annotation"` cases;
  - For secret update event can be checked by `"should validate when a missing secret is recreated with annotation"`;
  - For secret delete event can be checked by `"should validate the Build after secret deletion"` and `"should not validate the Build after a secret deletion"`;
 
All actions are covered by current cases, so I think `"when the build reconciles on secret events"` should not be added again.