### PR TITLE
Refactor build status for validating sourceURL

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -32,6 +32,8 @@ const (
 	MultipleSecretRefNotFound BuildReason = "MultipleSecretRefNotFound"
 	// RuntimePathsCanNotBeEmpty indicates that the spec.runtime feature is used but the paths were not specified
 	RuntimePathsCanNotBeEmpty BuildReason = "RuntimePathsCanNotBeEmpty"
+	// RemoteRepositoryUnreachable indicates the referenced repository is unreachable
+	RemoteRepositoryUnreachable BuildReason = "RemoteRepositoryUnreachable"
 	// AllValidationsSucceeded indicates a Build was successfully validated
 	AllValidationsSucceeded = "all validations succeeded"
 )

--- a/test/integration/build_to_git_test.go
+++ b/test/integration/build_to_git_test.go
@@ -54,7 +54,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -77,7 +78,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("remote repository unreachable"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("remote repository unreachable"))
 		})
 	})
 
@@ -102,7 +104,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -125,7 +128,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("remote repository unreachable"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("remote repository unreachable"))
 		})
 	})
 
@@ -151,7 +155,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(err).To(BeNil())
 			// this one is validating file protocol
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("invalid source url"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("invalid source url"))
 		})
 	})
 
@@ -176,7 +181,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(err).To(BeNil())
 			// skip validation due to false annotation
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -203,7 +209,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
 			// Because github enterprise always require authentication, this validation will fail while
 			// the repository could not be found.
-			Expect(buildObject.Status.Reason).To(ContainSubstring("no such host"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(ContainSubstring("no such host"))
 		})
 
 		It("should not validate sourceURL because a referenced secret exists", func() {
@@ -232,7 +239,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 
 			// Because this build references a source secret, Build controller will skip this validation.
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -259,7 +267,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			// Because sourceURL with git@ format implies that authentication is required,
 			// this validation will be skipped and build will be successful.
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("the source url requires authentication"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("the source url requires authentication"))
 		})
 	})
 
@@ -286,7 +295,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			// Because sourceURL with ssh format implies that authentication is required,
 			// this validation will be skipped and build will be successful.
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("the source url requires authentication"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("the source url requires authentication"))
 		})
 	})
 })


### PR DESCRIPTION
Because we have refactor build status to use `message` and one-word `reason`, we need to change validate sourceURL cases based on it.

- add a new const `RemoteRepositoryUnreachable` to indicate verify sourceURL failed;
- update all related validate sourceURL test cases;
- refactor validate sourceURL func in build controller;
