### PR TITLE
Add build quotes to the waiter tool

### DIFF
--- a/cmd/waiter/README.md
+++ b/cmd/waiter/README.md
@@ -22,3 +22,15 @@ And:
 ```sh
 waiter done
 ```
+
+Feeling patient? Try:
+
+```sh
+waiter quote
+```
+
+Or print a random build-related message while waiting:
+
+```sh
+waiter start --motd
+```

--- a/cmd/waiter/main.go
+++ b/cmd/waiter/main.go
@@ -15,6 +15,7 @@ import (
 type settings struct {
 	lockFile string        // path to lock file
 	timeout  time.Duration // how long wait for 'done'
+	motd     bool          // print a build quote while waiting
 }
 
 const longDesc = `
@@ -48,6 +49,7 @@ var (
 	rootCmd  = newRootCmd()
 	startCmd = newStartCmd()
 	doneCmd  = newDoneCmd()
+	quoteCmd = newQuoteCmd()
 )
 
 // defaultTimeout default timeout duration.
@@ -68,6 +70,7 @@ func init() {
 
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(doneCmd)
+	rootCmd.AddCommand(quoteCmd)
 }
 
 func newRootCmd() *cobra.Command {
@@ -79,13 +82,29 @@ func newRootCmd() *cobra.Command {
 }
 
 func newStartCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:          "start",
 		Short:        "Starts the wait, and holds until `done` is issued.",
 		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			w := NewWaiter(flagValues)
 			return w.Wait()
+		},
+	}
+
+	cmd.Flags().BoolVar(&flagValues.motd, "motd", false, "print a random build quote while waiting")
+
+	return cmd
+}
+
+func newQuoteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "quote",
+		Short:        "Print a random build-related message.",
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			printMotd()
+			return nil
 		},
 	}
 }

--- a/cmd/waiter/main_test.go
+++ b/cmd/waiter/main_test.go
@@ -62,6 +62,19 @@ var _ = Describe("Waiter", func() {
 		close(doneCh)
 	}
 
+	When("quote is issued", func() {
+		var session *gexec.Session
+
+		BeforeEach(func() {
+			session = run("quote")
+		})
+
+		It("prints a ship and a build-related message", func() {
+			Eventually(session).Should(gbytes.Say("harbor|layers|Shipwright|digest|BuildRun|kubectl"))
+			Eventually(session).Should(gexec.Exit(0))
+		})
+	})
+
 	When("--help is passed", func() {
 		var session *gexec.Session
 

--- a/cmd/waiter/quotes.go
+++ b/cmd/waiter/quotes.go
@@ -1,0 +1,54 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"strings"
+)
+
+const shipASCII = `
+        |    |    |
+       )_)  )_)  )_)
+      )___))___))___)\
+     )____)____)_____)\\
+_____|____|____|____\\\
+\                     /
+`
+
+var buildQuotes = []string{
+	"Your image is building. The harbor awaits.",
+	"Layers cache or layers don't — there is no try without push.",
+	"Shipwright never sinks; it only retries.",
+	"A smooth sea never made a skilled shipbuilder.",
+	"May your digests be immutable and your CVEs be zero.",
+	"Build once, run anywhere. Debug twice, everywhere.",
+	"The best time to pin your base image was yesterday. The second best time is now.",
+	"Every great container image starts as a humble Dockerfile.",
+	"Patience is a virtue, especially when pulling from Docker Hub.",
+	"Today's BuildRun is tomorrow's production deployment.",
+	"Keep calm and kubectl get buildruns -w.",
+	"From git clone to image push: the voyage continues.",
+}
+
+// randomBuildQuote returns a randomly selected build-related message.
+func randomBuildQuote() string {
+	return buildQuotes[rand.IntN(len(buildQuotes))]
+}
+
+// formatMotd renders the ASCII ship and a random quote for waiting pods.
+func formatMotd() string {
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(shipASCII, "\n"))
+	b.WriteString("\n\n  ")
+	b.WriteString(randomBuildQuote())
+	b.WriteString("\n")
+	return b.String()
+}
+
+// printMotd writes a message-of-the-day to stdout.
+func printMotd() {
+	fmt.Print(formatMotd())
+}

--- a/cmd/waiter/quotes_test.go
+++ b/cmd/waiter/quotes_test.go
@@ -1,0 +1,40 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRandomBuildQuote(t *testing.T) {
+	seen := make(map[string]struct{}, len(buildQuotes))
+	for range len(buildQuotes) * 3 {
+		quote := randomBuildQuote()
+		if quote == "" {
+			t.Fatal("expected non-empty quote")
+		}
+		seen[quote] = struct{}{}
+	}
+	if len(seen) != len(buildQuotes) {
+		t.Fatalf("expected all %d quotes to appear eventually, got %d", len(buildQuotes), len(seen))
+	}
+}
+
+func TestFormatMotd(t *testing.T) {
+	motd := formatMotd()
+	containsQuote := false
+	for _, quote := range buildQuotes {
+		if strings.Contains(motd, quote) {
+			containsQuote = true
+			break
+		}
+	}
+	if !containsQuote {
+		t.Fatalf("expected motd to contain a build quote, got: %q", motd)
+	}
+	if !strings.Contains(motd, "|") {
+		t.Fatalf("expected motd to contain the ASCII ship, got: %q", motd)
+	}
+}

--- a/cmd/waiter/waiter.go
+++ b/cmd/waiter/waiter.go
@@ -64,6 +64,10 @@ func (w *Waiter) retry() error {
 
 // Wait wait for the lock-file to be removed, or timeout.
 func (w *Waiter) Wait() error {
+	if w.flagValues.motd {
+		printMotd()
+	}
+
 	pid := os.Getpid()
 	if err := w.save(pid); err != nil {
 		return err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `waiter` binary exists to hold pods while builds run in the background. This adds a small bit of encouragement for anyone staring at a waiting pod.

- **`waiter quote`** — prints an ASCII ship and a random build-related message
- **`waiter start --motd`** — optionally prints a quote when waiting begins

## Example

```
$ waiter quote

        |    |    |
       )_)  )_)  )_)
      )___))___))___)\
     )____)____)_____)\\
_____|____|____|____\\\
\                     /

  Your image is building. The harbor awaits.
```

## Testing

- `go test ./cmd/waiter/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f81a2df9-283c-4a70-ae67-ad8d081fb868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f81a2df9-283c-4a70-ae67-ad8d081fb868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

