### PR TITLE
fix(waiter): stop ticker goroutine with NewTicker

### DIFF
--- a/cmd/waiter/waiter.go
+++ b/cmd/waiter/waiter.go
@@ -44,8 +44,8 @@ func (w *Waiter) retry() error {
 	timer := time.NewTimer(w.flagValues.timeout)
 	defer timer.Stop()
 
-	// Verify on file existence every 100ms. Prefer NewTicker over time.Tick so
-	// the underlying goroutine can be stopped when retry returns.
+	// Verify file existence every 100ms. Use NewTicker so the ticker can be
+	// stopped immediately when retry returns.
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/cmd/waiter/waiter.go
+++ b/cmd/waiter/waiter.go
@@ -44,14 +44,16 @@ func (w *Waiter) retry() error {
 	timer := time.NewTimer(w.flagValues.timeout)
 	defer timer.Stop()
 
-	// Verify on file existence every 100ms
-	ticker := time.Tick(100 * time.Millisecond)
+	// Verify on file existence every 100ms. Prefer NewTicker over time.Tick so
+	// the underlying goroutine can be stopped when retry returns.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-timer.C:
 			return fmt.Errorf("%w: elapsed %v seconds", ErrTimeout, w.flagValues.timeout.Seconds())
-		case <-ticker:
+		case <-ticker.C:
 			if _, err := os.Stat(w.flagValues.lockFile); err != nil && os.IsNotExist(err) {
 				log.Printf("Done! Condition has been reached\n")
 				return nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces `time.Tick` with `time.NewTicker` + `defer ticker.Stop()` in `cmd/waiter/waiter.go`.
- Avoids leaving an unstoppable ticker goroutine for the waiter process lifetime when `retry` returns on done or timeout.
- Behavior is unchanged: still polls the lock file every 100ms until removal or timeout.

## Test plan
- [x] `go test ./cmd/waiter/ -count=1 -v` (4/4 passed)
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00cb6cba-d311-406c-a2e4-1479c2943b3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00cb6cba-d311-406c-a2e4-1479c2943b3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

